### PR TITLE
ci: enable workflow_dispatch for PR smoke workflow (minimal)

### DIFF
--- a/.github/workflows/pr-smoke-and-outdated.yml
+++ b/.github/workflows/pr-smoke-and-outdated.yml
@@ -1,6 +1,7 @@
 name: PR smoke & outdated report (PHP 7.4)
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Adds workflow_dispatch so the PR smoke job can be manually dispatched for testing and validation.